### PR TITLE
[ui] Add old quit keybind

### DIFF
--- a/cmd/keybindings.go
+++ b/cmd/keybindings.go
@@ -35,6 +35,7 @@ const (
 	KeyCancel                      Key = "Cancel"
 	KeySuspend                     Key = "Suspend"
 	KeyQuit                        Key = "Quit"
+	KeyQuitWithConfirm             Key = "QuitWithConfirm"
 	KeySwitch                      Key = "Switch"
 	KeyClose                       Key = "Close"
 	KeyHelp                        Key = "Help"
@@ -104,6 +105,12 @@ var (
 			Title:   "Quit",
 			Context: KeyContextApp,
 			Kb:      Keybinding{tcell.KeyRune, 'Q', tcell.ModNone},
+			Global:  true,
+		},
+		KeyQuitWithConfirm: {
+			Title:   "QuitWithConfirm",
+			Context: KeyContextApp,
+			Kb:      Keybinding{tcell.KeyRune, 'q', tcell.ModNone},
 			Global:  true,
 		},
 		KeyMenu: {

--- a/ui/filepicker.go
+++ b/ui/filepicker.go
@@ -105,6 +105,9 @@ func filePickerTable() *tview.Table {
 		case cmd.KeyQuit:
 			go quit()
 
+		case cmd.KeyQuitWithConfirm:
+			go quitWithConfirm()
+
 		case cmd.KeyHelp:
 			showHelp()
 

--- a/ui/functions.go
+++ b/ui/functions.go
@@ -38,6 +38,7 @@ var functions = map[FunctionContext]map[cmd.Key]func() bool{
 		cmd.KeyProgressView:              progress,
 		cmd.KeyPlayerHide:                hideplayer,
 		cmd.KeyQuit:                      quit,
+		cmd.KeyQuitWithConfirm:           quitWithConfirm,
 	},
 	FunctionCreate: {
 		cmd.KeyAdapterTogglePower:        createPower,
@@ -247,6 +248,11 @@ func quit() bool {
 	StopUI()
 
 	return true
+}
+
+// quitWithConfirm first prompts user to confirm and then exits the application
+func quitWithConfirm() bool {
+	return confirmQuit() && quit()
 }
 
 // createPower sets the oncreate handler for the power submenu option.

--- a/ui/help.go
+++ b/ui/help.go
@@ -29,7 +29,7 @@ func showHelp() {
 		"Trust selected device":            "t",
 		"Remove device from adapter":       "d",
 		"Cancel operation":                 "Ctrl+x",
-		"Quit":                             "q",
+		"Quit":                             "q/Q",
 	}
 
 	filePickerKeyBindings := map[string]string{

--- a/ui/menubar.go
+++ b/ui/menubar.go
@@ -83,6 +83,10 @@ var (
 				Key:     cmd.KeyQuit,
 				OnClick: true,
 			},
+			{
+				Key:     cmd.KeyQuitWithConfirm,
+				OnClick: true,
+			},
 		},
 		"device": {
 			{

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -83,7 +83,7 @@ func StartUI() {
 
 	UI.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		operation := cmd.KeyOperation(event)
-		if operation != cmd.KeyQuit && event.Key() == tcell.KeyCtrlC {
+		if operation != cmd.KeyQuit && operation != cmd.KeyQuitWithConfirm && event.Key() == tcell.KeyCtrlC {
 			return nil
 		}
 


### PR DESCRIPTION
Between v0.1.3 and v0.1.7, the change was made to change the default 'Quit' keybind was changed from 'q' to 'Shift+q'. Additionally the quit confirmation no longer displays. The help menu has been updated and previous behavior restored in a way that does not conflict with the updated quit behavior.