### PR TITLE
cmd: fix version print if no `@` is present

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -377,7 +377,7 @@ func cmdOptionVersion() {
 
 	versionInfo := strings.Split(Version, "@")
 	if len(versionInfo) < 2 {
-		Print(fmt.Sprintf(text, versionInfo), 0)
+		Print(fmt.Sprintf(text, Version), 0)
 	}
 
 	text += " (%s)"


### PR DESCRIPTION
Just a tiny fix, previously, when embedding a version without `@`, the version command would have printed

```
./bluetuith --version
Bluetuith v[0.2.0]
```

now it prints

```
./bluetuith --version
Bluetuith v0.2.0
```