### PR TITLE
fix: declared module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/darkhz/bluetuith
+module github.com/bluetuith-org/bluetuith
 
 go 1.25
 


### PR DESCRIPTION
Solves the following installation error

```
go: downloading github.com/bluetuith-org/bluetuith v0.2.6
go: github.com/bluetuith-org/bluetuith@latest: version constraints conflict:
        github.com/bluetuith-org/bluetuith@v0.2.6: parsing go.mod:
        module declares its path as: github.com/darkhz/bluetuith
                but was required as: github.com/bluetuith-org/bluetuith
```